### PR TITLE
fix: restore vfox and mise PR regression coverage

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -3,9 +3,17 @@ name: vfox E2E tests
 on:
   push:
     branches: [main]
-    paths: ['lib']
+    paths:
+      - '.github/workflows/e2e_test.yaml'
+      - 'metadata.lua'
+      - 'hooks/**'
+      - 'lib/**'
   pull_request:
-    paths: ['lib']
+    paths:
+      - '.github/workflows/e2e_test.yaml'
+      - 'metadata.lua'
+      - 'hooks/**'
+      - 'lib/**'
   workflow_dispatch:
   schedule:
     # Runs at 12am UTC
@@ -14,10 +22,13 @@ on:
 jobs:
   e2e_tests:
     strategy:
+      fail-fast: false
       matrix:
         # ref: https://github.com/actions/runner-images
         os: [ubuntu-22.04, macos-latest, windows-2022]
     runs-on: ${{ matrix.os }}
+    env:
+      ELIXIR_PLUGIN_REF: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -47,13 +58,13 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           vfox add --source https://github.com/version-fox/vfox-erlang/archive/refs/heads/main.zip erlang
-          vfox add --source https://github.com/version-fox/vfox-elixir/archive/${GITHUB_REF}.zip elixir
+          vfox add --source https://github.com/version-fox/vfox-elixir/archive/${ELIXIR_PLUGIN_REF}.zip elixir
 
       - name: add vfox-erlang & vfox-elixir plugin
         if: runner.os == 'Windows'
         run: |
           vfox add --source https://github.com/version-fox/vfox-erlang/archive/refs/heads/main.zip erlang
-          vfox add --source https://github.com/version-fox/vfox-elixir/archive/$env:GITHUB_REF.zip elixir
+          vfox add --source https://github.com/version-fox/vfox-elixir/archive/$env:ELIXIR_PLUGIN_REF.zip elixir
 
       - name: install Erlang/OTP & Elixir by vfox-erlang & vfox-elixir plugin (Linux)
         if: runner.os == 'Linux'
@@ -94,7 +105,7 @@ jobs:
           elixir hello.ex
 
       - name: install Erlang/OTP & Elixir by vfox-erlang & vfox-elixir plugin (Darwin)
-        if: runner.os == 'MacOS'
+        if: runner.os == 'macOS'
         run: |
           brew install autoconf libxslt fop wxwidgets openssl
           export MAKEFLAGS=-j4

--- a/.github/workflows/mise_e2e_test.yaml
+++ b/.github/workflows/mise_e2e_test.yaml
@@ -3,9 +3,17 @@ name: mise E2E tests
 on:
   push:
     branches: [main]
-    paths: ['lib']
+    paths:
+      - '.github/workflows/mise_e2e_test.yaml'
+      - 'metadata.lua'
+      - 'hooks/**'
+      - 'lib/**'
   pull_request:
-    paths: ['lib']
+    paths:
+      - '.github/workflows/mise_e2e_test.yaml'
+      - 'metadata.lua'
+      - 'hooks/**'
+      - 'lib/**'
   workflow_dispatch:
   schedule:
     # Runs at 12am UTC
@@ -14,6 +22,7 @@ on:
 jobs:
   mise_e2e_tests:
     strategy:
+      fail-fast: false
       matrix:
         # ref: https://github.com/actions/runner-images
         os: [ubuntu-22.04, macos-latest]
@@ -34,6 +43,12 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           mise --version
 
+      - name: Link local Elixir plugin for PR validation
+        if: runner.os != 'Windows'
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          mise plugins link vfox-elixir-ci "$GITHUB_WORKSPACE"
+
       - name: Install Erlang/OTP & Elixir via mise (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -42,18 +57,15 @@ jobs:
           export MAKEFLAGS=-j4
           export PATH="$HOME/.local/bin:$PATH"
           
-          # Install via mise
           mise install vfox:version-fox/vfox-erlang@26.2.3
           mise use -g vfox:version-fox/vfox-erlang@26.2.3
-          eval "$(mise activate bash --shims)"
+          eval "$(mise env)"
           which erl
-          echo "===============PATH==============="
-          echo $PATH
-          echo "===============PATH==============="
-          
-          mise install vfox:version-fox/vfox-elixir@1.16.2
-          mise use -g vfox:version-fox/vfox-elixir@1.16.2
-          eval "$(mise activate bash --shims)"
+          which erlc
+
+          mise install vfox-elixir-ci@1.16.2
+          mise use -g vfox-elixir-ci@1.16.2
+          eval "$(mise env)"
           elixirc -v
           cd assets
           elixir hello.ex
@@ -66,18 +78,15 @@ jobs:
           export MAKEFLAGS=-j4
           export PATH="$HOME/.local/bin:$PATH"
           
-          # Install via mise
           mise install vfox:version-fox/vfox-erlang@26.2.3
           mise use -g vfox:version-fox/vfox-erlang@26.2.3
-          eval "$(mise activate bash)"
+          eval "$(mise env)"
           which erl
-          echo "===============PATH==============="
-          echo $PATH
-          echo "===============PATH==============="
-          
-          mise install vfox:version-fox/vfox-elixir@1.16.2
-          mise use -g vfox:version-fox/vfox-elixir@1.16.2
-          eval "$(mise activate bash)"
+          which erlc
+
+          mise install vfox-elixir-ci@1.16.2
+          mise use -g vfox-elixir-ci@1.16.2
+          eval "$(mise env)"
           elixirc -v
           cd assets
           elixir hello.ex

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -14,7 +14,12 @@ function PLUGIN:PostInstall(ctx)
     elseif os.getenv("VFOX_ELIXIR_MIRROR") == "hex" then
         return
     else
-        install_cmd = "cd " .. path .. " && make"
+        local erlang_bin = elixirUtils.find_erlang_bin()
+        if erlang_bin then
+            install_cmd = "cd " .. path .. " && PATH=" .. erlang_bin .. ":$PATH make"
+        else
+            install_cmd = "cd " .. path .. " && make"
+        end
         local status = os.execute(install_cmd)
         if status ~= 0 then
             error("Elixir install failed, please check the stdout for details.")

--- a/lib/elixir_utils.lua
+++ b/lib/elixir_utils.lua
@@ -65,12 +65,32 @@ function elixir_utils.check_version_existence(url)
     end
 end
 
+function elixir_utils.find_erlang_bin()
+    local handle = io.popen("which erlc 2>/dev/null")
+    local result = handle:read("*l")
+    handle:close()
+    if result and result ~= "" then
+        return result:match("(.+)/")
+    end
+
+    local home = os.getenv("HOME") or ""
+    local mise_dir = os.getenv("MISE_DATA_DIR") or (home .. "/.local/share/mise")
+    handle = io.popen("find '" .. mise_dir .. "/installs' -name erlc -type f 2>/dev/null | head -1")
+    result = handle:read("*l")
+    handle:close()
+    if result and result ~= "" then
+        return result:match("(.+)/")
+    end
+
+    return nil
+end
+
 function elixir_utils.check_erlang_existence()
     print("Check Erlang/OTP existence...")
-    local status = os.execute("which erlc")
-    if status ~= 0 then
-        error("Please install Erlang/OTP before you install Elixir.")
+    if elixir_utils.find_erlang_bin() then
+        return
     end
+    error("Please install Erlang/OTP before you install Elixir.")
 end
 
 function elixir_utils.get_elixir_release_verions_in_linux()

--- a/metadata.lua
+++ b/metadata.lua
@@ -13,6 +13,9 @@ PLUGIN.license = "Apache 2.0"
 --- Plugin description
 PLUGIN.description = "Elixir vfox plugin, support for managing multiple Elixir language versions in Windows & Uinx-like system."
 
+--- Erlang/OTP must be on PATH when compiling Elixir from source.
+PLUGIN.depends = { "erlang" }
+
 
 --- !!! OPTIONAL !!!
 --[[


### PR DESCRIPTION
## Summary
Make PR CI exercise the actual plugin changes across both `vfox` and `mise`, and fix the recent `mise` regression where Elixir source builds could not find `erlc` during install hooks.

## Changes
- expand `mise E2E tests` PR triggers to cover plugin code and workflow changes
- link the checked-out repository as a local plugin in `mise` CI so PR runs validate the branch under review
- declare the Elixir plugin's Erlang hook dependency for `mise` and inject the resolved Erlang `bin` directory into the Elixir build command when needed
- expand `vfox E2E tests` PR triggers to cover plugin code and workflow changes
- make `vfox` PR runs fetch the plugin archive from the current PR head SHA instead of a branch ref
- fix the `macOS` runner condition in `vfox E2E tests`
- disable matrix `fail-fast` so platform regressions report independently

## Testing
- latest PR checks now include all five regression jobs:
  - `e2e_tests (ubuntu-22.04)`
  - `e2e_tests (macos-latest)`
  - `e2e_tests (windows-2022)`
  - `mise_e2e_tests (ubuntu-22.04)`
  - `mise_e2e_tests (macos-latest)`
- previous `mise` PR run reproduced the macOS `make: erlc: No such file or directory` failure
- after the fix, the subsequent `mise` PR run passed on both Ubuntu and macOS

## Context
The recent failures were not caused by a repo logic change alone. The breakage showed up after `mise` changed how vfox install-hook environments are built, which exposed this plugin's assumption that `erlc` would already be on `PATH`. This PR fixes that assumption and also makes sure future PRs run the full `vfox` and `mise` regression coverage against the code actually under review.
